### PR TITLE
Switch to registerBoundHelper

### DIFF
--- a/app/assets/javascripts/ember-rails-assets.js
+++ b/app/assets/javascripts/ember-rails-assets.js
@@ -1,5 +1,4 @@
-Ember.Handlebars.registerHelper("asset-path", function(name) {
-  var path;
-  path = window.ASSETS.path(name);
+Ember.Handlebars.registerBoundHelper("asset-path", function(name) {
+  var path = window.ASSETS.path(name);
   return new Ember.Handlebars.SafeString(path);
 });


### PR DESCRIPTION
`registerHelper` does not resolve variables that are passed in. So, a call for `{{asset-path myVar}}` passes the string "myVar" to the helper. Using `registerBoundHelper` fixes this and also binds the helper to the variable so that the helper recomputes when the value changes.

Here is some more info on the difference between `registerHelper` and `registerBoundHelper`: http://stackoverflow.com/a/18012442/680847
